### PR TITLE
Add RabbitMQ Export Stage

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,6 +9,7 @@ import logging
 from feed_parsers.implemented_feeds import CbcSourceFeed
 from feed_parsers.source_feed import SourceFeed
 from pipeline.feed_manager import FeedManager
+from pipeline.export_manager import ExportManager
 from pipeline.pipeline import Pipeline
 
 SOURCE_CLASSES = {
@@ -47,7 +48,8 @@ if __name__ == '__main__':
 
     Pipeline(
         stages = [
-            FeedManager(feeds=feeds)
+            FeedManager(feeds=feeds),
+            ExportManager()
         ],
         print_articles = not os.getenv('SUPPRESS_PRINT')
     ).start()

--- a/pipeline/export_manager.py
+++ b/pipeline/export_manager.py
@@ -5,27 +5,27 @@ import json
 from pipeline.pipeline_stage import PipelineStage
 
 class ExportManager(PipelineStage):
-  def __init__(self):
-    super().__init__()
-    """
-    Set up the RabbitMQ connection and channel
-    """
-    logging.getLogger('pika').setLevel(logging.WARNING)
-    url = os.environ.get('CLOUDAMQP_URL', 'amqp://guest:guest@localhost:5672/%2f')
-    params = pika.URLParameters(url)
-    self._connection = pika.BlockingConnection(params)
-    self._channel = self._connection.channel()
+    def __init__(self):
+        super().__init__()
+        """
+        Set up the RabbitMQ connection and channel
+        """
+        logging.getLogger('pika').setLevel(logging.WARNING)
+        url = os.environ.get('CLOUDAMQP_URL', 'amqp://guest:guest@localhost:5672/%2f')
+        params = pika.URLParameters(url)
+        self._connection = pika.BlockingConnection(params)
+        self._channel = self._connection.channel()
 
-  def _process_one(self, to_process):
-    """
-    Declare the articles queue, and send the article JSON to it
-    """
-    self._channel.queue_declare(queue='articles')
-    self._channel.basic_publish(exchange='', routing_key='articles', body=json.dumps(to_process.__dict__, indent=4, sort_keys=True, default=str))
-    return to_process
+    def _process_one(self, to_process):
+        """
+        Declare the articles queue, and send the article JSON to it
+        """
+        self._channel.queue_declare(queue='articles')
+        self._channel.basic_publish(exchange='', routing_key='articles', body=json.dumps(to_process.__dict__, indent=4, sort_keys=True, default=str))
+        return to_process
 
-  def destroy(self):
-    """
-    Close the RabbitMQ connection
-    """
-    self._connection.close()
+    def _post_process(self):
+        """
+        Close the RabbitMQ connection
+        """
+        self._connection.close()

--- a/pipeline/export_manager.py
+++ b/pipeline/export_manager.py
@@ -1,0 +1,31 @@
+import logging
+import pika
+import os
+import json
+from pipeline.pipeline_stage import PipelineStage
+
+class ExportManager(PipelineStage):
+  def __init__(self):
+    super().__init__()
+    """
+    Set up the RabbitMQ connection and channel
+    """
+    logging.getLogger('pika').setLevel(logging.WARNING)
+    url = os.environ.get('CLOUDAMQP_URL', 'amqp://guest:guest@localhost:5672/%2f')
+    params = pika.URLParameters(url)
+    self._connection = pika.BlockingConnection(params)
+    self._channel = self._connection.channel()
+
+  def _process_one(self, to_process):
+    """
+    Declare the articles queue, and send the article JSON to it
+    """
+    self._channel.queue_declare(queue='articles')
+    self._channel.basic_publish(exchange='', routing_key='articles', body=json.dumps(to_process.__dict__, indent=4, sort_keys=True, default=str))
+    return to_process
+
+  def destroy(self):
+    """
+    Close the RabbitMQ connection
+    """
+    self._connection.close()

--- a/pipeline/pipeline_stage.py
+++ b/pipeline/pipeline_stage.py
@@ -29,7 +29,8 @@ class PipelineStage:
 
 
     def process(self, to_process: [NewsArticle]):
-        self.emit(self._process_one(x) for x in to_process)
+        self.emit([self._process_one(x) for x in to_process])
+        self.destroy()
 
     @abstractmethod
     def _process_one(self, to_process: NewsArticle) -> NewsArticle:
@@ -44,3 +45,8 @@ class PipelineStage:
         """
         raise NotImplementedError
 
+    @abstractmethod
+    def destroy(self):
+        """
+        Perform any needed cleanup for the stage
+        """

--- a/pipeline/pipeline_stage.py
+++ b/pipeline/pipeline_stage.py
@@ -50,3 +50,4 @@ class PipelineStage:
         """
         Perform any needed cleanup for the stage
         """
+        raise NotImplementedError

--- a/pipeline/pipeline_stage.py
+++ b/pipeline/pipeline_stage.py
@@ -30,7 +30,7 @@ class PipelineStage:
 
     def process(self, to_process: [NewsArticle]):
         self.emit([self._process_one(x) for x in to_process])
-        self.destroy()
+        self._post_process()
 
     @abstractmethod
     def _process_one(self, to_process: NewsArticle) -> NewsArticle:
@@ -46,7 +46,7 @@ class PipelineStage:
         raise NotImplementedError
 
     @abstractmethod
-    def destroy(self):
+    def _post_process(self):
         """
         Perform any needed cleanup for the stage
         """

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ PyYAML==5.4.1
 sgmllib3k==1.0.0
 six==1.15.0
 tzlocal==2.1
+pika==1.1.0


### PR DESCRIPTION
Adds new pipeline stage to export the news article jsons
Adds abstract method `destroy` to the pipeline stage which can be overwritten to perform any cleanup needed (here it is used to close the rabbitmq connection).

![Power Rabbit](https://media.giphy.com/media/b4WlNF7ZT9yI8/giphy.gif)